### PR TITLE
fix error on last data byte of wideband and receiver packets

### DIFF
--- a/rtl/Ethernet/Tx_send.v
+++ b/rtl/Ethernet/Tx_send.v
@@ -144,7 +144,7 @@ UDP2:
 					 11'd4: tx_data <= sequence_number[23:16];
 					 11'd5: begin tx_data <= sequence_number[15:8]; Tx_fifo_rdreq <= 1'b1; end
 					 11'd6: begin tx_data <= sequence_number[7:0]; Tx_fifo_rdreq <= 1'b1; end  	
-					 11'd1029: Tx_fifo_rdreq <= 1'b0; // Total-3
+					 11'd1029: begin Tx_fifo_rdreq <= 1'b0; tx_data <= PHY_Tx_data; end // Total-3
 					 default: tx_data <= PHY_Tx_data;		 
 				endcase				
 				byte_no <= byte_no + 11'd1;
@@ -178,7 +178,7 @@ WIDE2:
 					 11'd4: tx_data <= spec_seq_number[23:16];
 					 11'd5: begin tx_data <= spec_seq_number[15:8]; sp_fifo_rdreq <= 1'b1; end
 					 11'd6: begin tx_data <= spec_seq_number[7:0]; sp_fifo_rdreq <= 1'b1; end  	
-					 11'd1029: sp_fifo_rdreq <= 1'b0; // Total-3
+					 11'd1029: begin sp_fifo_rdreq <= 1'b0; tx_data <= sp_fifo_rddata; end // Total-3
 					 default: tx_data <= sp_fifo_rddata;		 
 				endcase				
 				byte_no <= byte_no + 11'd1;


### PR DESCRIPTION
This fixes an old bug in the cva9 ethernet code that corrupts the last data byte of the sent packet.  The noise produced is generally very low and I doubt this fix will be noticeable for most uses.